### PR TITLE
イベントページのナビゲーションのレイアウト崩れを修正

### DIFF
--- a/_layouts/2013layout.html
+++ b/_layouts/2013layout.html
@@ -9,20 +9,16 @@
 <body>
     <header>
         <nav class="top-bar">
-            <div class="row">
-                <div class="small-10 small-centered columns">
-                    <ul class="title-area">
-                        <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
-                    </ul>
-                    <section class="top-bar-section">
-                        <ul class="right">
-                            <li><a href="/2013/program.html">プログラム</a></li>
-                            <li><a href="/2013/sponsors.html">スポンサー</a></li>
-                            <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
-                        </ul>
-                    </section>
-                </div>
-            </div>
+            <ul class="title-area">
+                <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
+            </ul>
+            <section class="top-bar-section">
+                <ul class="right">
+                    <li><a href="/2013/program.html">プログラム</a></li>
+                    <li><a href="/2013/sponsors.html">スポンサー</a></li>
+                    <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
+                </ul>
+            </section>
         </nav>
     </header>
 

--- a/_layouts/2013top.html
+++ b/_layouts/2013top.html
@@ -9,20 +9,16 @@
 <body>
     <header>
         <nav class="top-bar">
-            <div class="row">
-                <div class="small-10 small-centered columns">
-                    <ul class="title-area">
-                        <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
-                    </ul>
-                    <section class="top-bar-section">
-                        <ul class="right">
-                            <li><a href="/2013/program.html">プログラム</a></li>
-                            <li><a href="/2013/sponsors.html">スポンサー</a></li>
-                            <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
-                        </ul>
-                    </section>
-                </div>
-            </div>
+            <ul class="title-area">
+                <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
+            </ul>
+            <section class="top-bar-section">
+                <ul class="right">
+                    <li><a href="/2013/program.html">プログラム</a></li>
+                    <li><a href="/2013/sponsors.html">スポンサー</a></li>
+                    <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
+                </ul>
+            </section>
         </nav>
     </header>
 

--- a/_layouts/2014layout.html
+++ b/_layouts/2014layout.html
@@ -9,21 +9,17 @@
 <body>
     <header>
         <nav class="top-bar">
-            <div class="row">
-                <div class="small-10 small-centered columns">
-                    <ul class="title-area">
-                        <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
-                    </ul>
-                    <section class="top-bar-section">
-                        <ul class="right">
-                            <li><a href="/2014/program.html">プログラム</a></li>
-                            <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
-                            <li><a href="/2014/sponsors.html">スポンサー</a></li>
-                            <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
-                        </ul>
-                    </section>
-                </div>
-            </div>
+            <ul class="title-area">
+                <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
+            </ul>
+            <section class="top-bar-section">
+                <ul class="right">
+                    <li><a href="/2014/program.html">プログラム</a></li>
+                    <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
+                    <li><a href="/2014/sponsors.html">スポンサー</a></li>
+                    <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
+                </ul>
+            </section>
         </nav>
     </header>
 

--- a/_layouts/2014top.html
+++ b/_layouts/2014top.html
@@ -18,21 +18,17 @@
 
     <header>
         <nav class="top-bar">
-            <div class="row">
-                <div class="small-10 small-centered columns">
-                    <ul class="title-area">
-                        <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
-                    </ul>
-                    <section class="top-bar-section">
-                        <ul class="right">
-                            <li><a href="/2014/program.html">プログラム</a></li>
-                            <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
-                            <li><a href="/2014/sponsors.html">スポンサー</a></li>
-                            <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
-                        </ul>
-                    </section>
-                </div>
-            </div>
+            <ul class="title-area">
+                <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
+            </ul>
+            <section class="top-bar-section">
+                <ul class="right">
+                    <li><a href="/2014/program.html">プログラム</a></li>
+                    <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
+                    <li><a href="/2014/sponsors.html">スポンサー</a></li>
+                    <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
+                </ul>
+            </section>
         </nav>
     </header>
 

--- a/_layouts/2015layout.html
+++ b/_layouts/2015layout.html
@@ -9,24 +9,20 @@
 <body>
     <header>
         <nav class="top-bar">
-            <div class="row">
-                <div class="small-10 small-centered columns">
-                    <ul class="title-area">
-                        <li class="name"><h1><a href="/2015/">{{ site.title }}</a></h1></li>
-                    </ul>
-                    <section class="top-bar-section">
-                        <ul class="right">
-                            <li><a href="/2015/camp.html">開発合宿</a></li>
-                            <li><a href="/2015/program.html">プログラム</a></li>
-                            <li><a href="/2015/faq.html">FAQ</a></li>
-                            <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
-                            <li><a href="/2015/sponsors.html">スポンサー募集</a></li>
-                            <li><a href="/2015/call4speakers.html">スピーカー募集</a></li>
-                            <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
-                        </ul>
-                    </section>
-                </div>
-            </div>
+            <ul class="title-area">
+                <li class="name"><h1><a href="/2015/">{{ site.title }}</a></h1></li>
+            </ul>
+            <section class="top-bar-section">
+                <ul class="right">
+                    <li><a href="/2015/camp.html">開発合宿</a></li>
+                    <li><a href="/2015/program.html">プログラム</a></li>
+                    <li><a href="/2015/faq.html">FAQ</a></li>
+                    <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
+                    <li><a href="/2015/sponsors.html">スポンサー募集</a></li>
+                    <li><a href="/2015/call4speakers.html">スピーカー募集</a></li>
+                    <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
+                </ul>
+            </section>
         </nav>
     </header>
 

--- a/_layouts/2015top.html
+++ b/_layouts/2015top.html
@@ -18,24 +18,20 @@
 
     <header>
         <nav class="top-bar">
-            <div class="row">
-                <div class="small-10 small-centered columns">
-                    <ul class="title-area">
-                        <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
-                    </ul>
-                    <section class="top-bar-section">
-                        <ul class="right">
-                            <li><a href="/2015/camp.html">開発合宿</a></li>
-                            <li><a href="/2015/program.html">プログラム</a></li>
-                            <li><a href="/2015/faq.html">FAQ</a></li>
-                            <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
-                            <li><a href="/2015/sponsors.html">スポンサー募集</a></li>
-                            <li><a href="/2015/call4speakers.html">スピーカー募集</a></li>
-                            <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
-                        </ul>
-                    </section>
-                </div>
-            </div>
+            <ul class="title-area">
+                <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
+            </ul>
+            <section class="top-bar-section">
+                <ul class="right">
+                    <li><a href="/2015/camp.html">開発合宿</a></li>
+                    <li><a href="/2015/program.html">プログラム</a></li>
+                    <li><a href="/2015/faq.html">FAQ</a></li>
+                    <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
+                    <li><a href="/2015/sponsors.html">スポンサー募集</a></li>
+                    <li><a href="/2015/call4speakers.html">スピーカー募集</a></li>
+                    <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
+                </ul>
+            </section>
         </nav>
     </header>
 

--- a/_layouts/2016layout.html
+++ b/_layouts/2016layout.html
@@ -9,26 +9,22 @@
 <body>
     <header>
         <nav class="top-bar">
-            <div class="row">
-                <div class="small-10 small-centered columns">
-                    <ul class="title-area">
-                        <li class="name"><h1><a href="/2016/">{{ site.title }}</a></h1></li>
-                    </ul>
-                    <section class="top-bar-section">
-                        <ul class="right">
-                            <!--
-                            <li><a href="/2016/program.html">プログラム</a></li>
-                            <li><a href="/2016/faq.html">FAQ</a></li>
-                            <li><a href="/2016/call4speakers.html">スピーカー募集</a></li>
-                            -->
-                            <li><a href="/2016/camp.html">開発合宿</a></li>
-                            <li><a href="/2016/sponsors.html">スポンサー募集</a></li>
-                            <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
-                            <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
-                        </ul>
-                    </section>
-                </div>
-            </div>
+            <ul class="title-area">
+                <li class="name"><h1><a href="/2016/">{{ site.title }}</a></h1></li>
+            </ul>
+            <section class="top-bar-section">
+                <ul class="right">
+                    <!--
+                    <li><a href="/2016/program.html">プログラム</a></li>
+                    <li><a href="/2016/faq.html">FAQ</a></li>
+                    <li><a href="/2016/call4speakers.html">スピーカー募集</a></li>
+                    -->
+                    <li><a href="/2016/camp.html">開発合宿</a></li>
+                    <li><a href="/2016/sponsors.html">スポンサー募集</a></li>
+                    <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
+                    <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
+                </ul>
+            </section>
         </nav>
     </header>
 

--- a/_layouts/2016top.html
+++ b/_layouts/2016top.html
@@ -18,26 +18,22 @@
 
     <header>
         <nav class="top-bar">
-            <div class="row">
-                <div class="small-10 small-centered columns">
-                    <ul class="title-area">
-                        <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
-                    </ul>
-                    <section class="top-bar-section">
-                        <ul class="right">
-                            <!--
-                            <li><a href="/2016/program.html">プログラム</a></li>
-                            <li><a href="/2016/faq.html">FAQ</a></li>
-                            <li><a href="/2016/call4speakers.html">スピーカー募集</a></li>
-                            -->
-                            <li><a href="/2016/camp.html">開発合宿</a></li>
-                            <li><a href="/2016/sponsors.html">スポンサー募集</a></li>
-                            <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
-                            <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
-                        </ul>
-                    </section>
-                </div>
-            </div>
+            <ul class="title-area">
+                <li class="name"><h1><a href="/">{{ site.title }}</a></h1></li>
+            </ul>
+            <section class="top-bar-section">
+                <ul class="right">
+                    <!--
+                    <li><a href="/2016/program.html">プログラム</a></li>
+                    <li><a href="/2016/faq.html">FAQ</a></li>
+                    <li><a href="/2016/call4speakers.html">スピーカー募集</a></li>
+                    -->
+                    <li><a href="/2016/camp.html">開発合宿</a></li>
+                    <li><a href="/2016/sponsors.html">スポンサー募集</a></li>
+                    <li><a href="https://suzuri.jp/hackerschamploo">公式グッズストア</a></li>
+                    <li><a href="https://docs.google.com/forms/d/1MGJ4bVv8hpyXeLjvcGzZDpl838ZGHPA_plLqX_BJSbA/viewform">お問い合わせ</a></li>
+                </ul>
+            </section>
         </nav>
     </header>
 


### PR DESCRIPTION
指摘事項をうけて修正 :bow:

> 2013-2015のヘッダナビゲーションが、崩れてます？（一番上の領域に入らないで、1段下がってるように見える）

from https://github.com/hackers-champloo/hackers-champloo.github.io/pull/46#issuecomment-203361039

