### PR TITLE
og:imageを海の画像に差し替え

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="author" content="{{ site.author }}">
 <meta name="description" content="{{ site.description }}">
+<meta property="og:image" content="/img/cover.jpg"/>
 <link rel="stylesheet" href="/css/normalize.css" />
 <link rel="stylesheet" href="/css/foundation.min.css" />
 <link rel="stylesheet" href="/css/style.css" />


### PR DESCRIPTION
サイトをシェアした歳に、HackersChamplooの画像ではなく、スンポンサー企業のロゴがシェアされてしまう問題の修正

海の画像で対応