### PR TITLE
`docker compose up`でjekyll serverを起動可能にします

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'github-pages', '~> 45'
+gem "github-pages", "~> 232", group: :jekyll_plugins

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    image: jekyll/jekyll:pages
+    command: >-
+      sh -c '
+        apk add --no-cache build-base ruby-dev linux-headers;
+        /usr/local/bin/bundle install;
+        /usr/local/bin/bundle exec jekyll serve --force_polling --host 0.0.0.0;
+      '
+    volumes:
+      - $PWD:/srv/jekyll
+    ports:
+      - 4000:4000


### PR DESCRIPTION
```shell
docker compose up
```

でjekyll serverを http://localhost:4000 として起動可能にします